### PR TITLE
[SPE-538] Update cage cli to use cross actions to build

### DIFF
--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -3,8 +3,6 @@ name: Release Cage CLI version
 # TEMP TO TEST BUILD
 on:
   push:
-    paths:
-      - .github/workflows/release-cli-version.yml
 
 # on:
 #   push:

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -67,6 +67,7 @@ jobs:
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
+          CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
           CARGO_HOME: ${{ github.workspace }}/.cargo
 
       - name: Upload as artifact

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -1,13 +1,9 @@
 name: Release Cage CLI version
 
-# TEMP TO TEST BUILD
 on:
   push:
-
-# on:
-#   push:
-#     tags:
-#       - "v*"
+    tags:
+      - "v*"
 
 env:
   RUST_BACKTRACE: 1
@@ -177,111 +173,111 @@ jobs:
           name: windows
           path: ./${{ env.RELEASE_DIR }}
 
-  # release-cli-version:
-  #   needs: [ get-version, compile-ubuntu, compile-macos, compile-windows ]
-  #   runs-on: ubuntu-latest
-  #   steps:
+  release-cli-version:
+    needs: [ get-version, compile-ubuntu, compile-macos, compile-windows ]
+    runs-on: ubuntu-latest
+    steps:
 
-  #     - name: Create Release
-  #       id: create-release
-  #       uses: actions/create-release@v1
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #       with:
-  #         tag_name: ${{ needs.get-version.outputs.version }}
-  #         release_name: ${{ needs.get-version.outputs.version }}
+      - name: Create Release
+        id: create-release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ needs.get-version.outputs.version }}
+          release_name: ${{ needs.get-version.outputs.version }}
 
-  #     - name: Download MacOS Artifacts
-  #       uses: actions/download-artifact@v1
-  #       with:
-  #         name: macos
+      - name: Download MacOS Artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: macos
 
-  #     - name: Download Linux Artifacts
-  #       uses: actions/download-artifact@v1
-  #       with:
-  #         name: linux
+      - name: Download Linux Artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: linux
 
-  #     - name: Download Windows Artifacts
-  #       uses: actions/download-artifact@v1
-  #       with:
-  #         name: windows
+      - name: Download Windows Artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: windows
 
-  #     - name: Upload Linux Release
-  #       uses: actions/upload-release-asset@v1
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #       with:
-  #         upload_url: ${{ steps.create-release.outputs.upload_url }}
-  #         asset_path: ./linux/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
-  #         asset_content_type: application/gzip
-  #         asset_name: ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+      - name: Upload Linux Release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: ./linux/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+          asset_content_type: application/gzip
+          asset_name: ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
 
-  #     - name: Upload MacOS Release
-  #       uses: actions/upload-release-asset@v1
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #       with:
-  #         upload_url: ${{ steps.create-release.outputs.upload_url }}
-  #         asset_path: ./macos/ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
-  #         asset_content_type: application/gzip
-  #         asset_name: ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+      - name: Upload MacOS Release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: ./macos/ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+          asset_content_type: application/gzip
+          asset_name: ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
 
-  #     - name: Upload Windows Release
-  #       uses: actions/upload-release-asset@v1
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #       with:
-  #         upload_url: ${{ steps.create-release.outputs.upload_url }}
-  #         asset_path: ./windows/ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
-  #         asset_content_type: application/gzip
-  #         asset_name: ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+      - name: Upload Windows Release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: ./windows/ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+          asset_content_type: application/gzip
+          asset_name: ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
 
-  # upload-artifacts-to-s3:
-  #   needs: [ get-version , compile-ubuntu, compile-macos, compile-windows ]
-  #   runs-on: ubuntu-latest
-  #   steps:
+  upload-artifacts-to-s3:
+    needs: [ get-version , compile-ubuntu, compile-macos, compile-windows ]
+    runs-on: ubuntu-latest
+    steps:
 
-  #     - name: Configure AWS credentials
-  #       uses: aws-actions/configure-aws-credentials@v1
-  #       with:
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         aws-region: us-east-1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
 
-  #     - name: Download MacOS Artifacts
-  #       uses: actions/download-artifact@v1
-  #       with:
-  #         name: macos
+      - name: Download MacOS Artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: macos
 
-  #     - name: Download Linux Artifacts
-  #       uses: actions/download-artifact@v1
-  #       with:
-  #         name: linux
+      - name: Download Linux Artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: linux
 
-  #     - name: Download Windows Artifacts
-  #       uses: actions/download-artifact@v1
-  #       with:
-  #         name: windows
+      - name: Download Windows Artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: windows
 
-  #     - name: Upload Windows CLI to S3
-  #       run: |
-  #         aws s3 cp ./windows/ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.WINDOWS_TARGET }}/ev-cage.tar.gz
+      - name: Upload Windows CLI to S3
+        run: |
+          aws s3 cp ./windows/ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.WINDOWS_TARGET }}/ev-cage.tar.gz
 
-  #     - name: Upload MacOS CLI to S3
-  #       run: |
-  #         aws s3 cp ./macos/ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.MACOS_TARGET }}/ev-cage.tar.gz
+      - name: Upload MacOS CLI to S3
+        run: |
+          aws s3 cp ./macos/ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.MACOS_TARGET }}/ev-cage.tar.gz
 
-  #     - name: Upload Ubuntu CLI to S3
-  #       run: |
-  #         aws s3 cp ./linux/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.LINUX_TARGET }}/ev-cage.tar.gz
+      - name: Upload Ubuntu CLI to S3
+        run: |
+          aws s3 cp ./linux/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.LINUX_TARGET }}/ev-cage.tar.gz
 
-  #     - uses: actions/checkout@v2
-  #     - name: Update install script in S3
-  #       run: |
-  #         sh ./scripts/generate-installer.sh ${{ needs.get-version.outputs.version }}
-  #         aws s3 cp scripts/install s3://cage-build-assets-${{ env.STAGE }}/cli/${{needs.get-version.outputs.version}}/install
-  #         aws s3 cp scripts/install s3://cage-build-assets-${{ env.STAGE }}/cli/install
-  #         aws s3 cp scripts/version s3://cage-build-assets-${{ env.STAGE }}/cli/${{needs.get-version.outputs.version}}/version
-  #         aws s3 cp scripts/version s3://cage-build-assets-${{ env.STAGE }}/cli/version
-  #         aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/cli/install"
-  #         aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/cli/version"
+      - uses: actions/checkout@v2
+      - name: Update install script in S3
+        run: |
+          sh ./scripts/generate-installer.sh ${{ needs.get-version.outputs.version }}
+          aws s3 cp scripts/install s3://cage-build-assets-${{ env.STAGE }}/cli/${{needs.get-version.outputs.version}}/install
+          aws s3 cp scripts/install s3://cage-build-assets-${{ env.STAGE }}/cli/install
+          aws s3 cp scripts/version s3://cage-build-assets-${{ env.STAGE }}/cli/${{needs.get-version.outputs.version}}/version
+          aws s3 cp scripts/version s3://cage-build-assets-${{ env.STAGE }}/cli/version
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/cli/install"
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/cli/version"

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -37,6 +37,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install musl-tools
+        run: sudo apt-get install musl-tools
+
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nighlty
+          toolchain: nightly
           override: true
           target: ${{ env.LINUX_TARGET }}
 

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -50,6 +50,9 @@ jobs:
         with:
             shared-key: "linux-cross-builds"
 
+      - name: Install cross
+        run: cargo install cross
+
       - name: Inject Version
         run: |
           sh ./scripts/insert-cli-version.sh ${{ needs.get-version.outputs.version }}
@@ -58,7 +61,6 @@ jobs:
         run: |
           mkdir ${{ env.BIN_DIR }}
           mkdir ${{ env.RELEASE_DIR }}
-          cargo install cross
           cross build --release --target ${{ env.LINUX_TARGET }} -Z registry-auth
           mv ./target/${{ env.LINUX_TARGET }}/release/ev-cage ./${{ env.BIN_DIR }}/ev-cage
           7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ./${{ env.RELEASE_DIR }}/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -90,7 +90,7 @@ jobs:
           override: true
 
       - name: Build CLI MacOs Target
-      - run: |
+        run: |
           cargo install cross
           cross build --release --target ${{ env.MACOS_TARGET }} -Z registry-auth
         env:

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -67,7 +67,6 @@ jobs:
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
-          CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
           CARGO_HOME: ${{ github.workspace }}/.cargo
 
       - name: Upload as artifact

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -89,6 +89,11 @@ jobs:
           toolchain: nightly
           target: ${{ env.MACOS_TARGET }}
           override: true
+      
+      - name: Download cached dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+            shared-key: "macos-cross-builds"
 
       - name: Build CLI MacOs Target
         run: |
@@ -140,6 +145,11 @@ jobs:
           toolchain: nightly
           target: ${{ env.WINDOWS_TARGET }}
           override: true
+
+      - name: Download cached dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+            shared-key: "windows-cross-builds"
 
       - name: Fetch dependencies
         run: cargo fetch -Z registry-auth

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -28,8 +28,8 @@ jobs:
     steps:
       - id: get-version
         run: |
-          echo "using version tag ${GITHUB_REF:11}"
-          echo ::set-output name=version::${GITHUB_REF:11}
+          echo "using version tag 0.1.15"
+          echo ::set-output name=version::0.1.15
 
   compile-ubuntu:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -1,9 +1,15 @@
 name: Release Cage CLI version
 
+# TEMP TO TEST BUILD
 on:
   push:
-    tags:
-      - "v*"
+    paths:
+      - .github/workflows/release-cli-version.yml
+
+# on:
+#   push:
+#     tags:
+#       - "v*"
 
 env:
   RUST_BACKTRACE: 1
@@ -33,17 +39,35 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nighlty
+          override: true
+          target: ${{ env.LINUX_TARGET }}
+
+      - name: Download cached dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+            shared-key: "linux-cross-builds"
+
       - name: Inject Version
         run: |
           sh ./scripts/insert-cli-version.sh ${{ needs.get-version.outputs.version }}
 
       - name: Build and Compress cli
-        # todo use evervault action with added 7zip
-        uses: davidnugent2425/cargo-static-build@master
-        with:
-          cmd: mkdir ${{ env.BIN_DIR }} ; mkdir ${{ env.RELEASE_DIR }} ; cargo build --release --target ${{ env.LINUX_TARGET }} ; mv ./target/${{ env.LINUX_TARGET }}/release/ev-cage ./${{ env.BIN_DIR }}/ev-cage ; 7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ./${{ env.RELEASE_DIR }}/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+        run: |
+          mkdir ${{ env.BIN_DIR }}
+          mkdir ${{ env.RELEASE_DIR }}
+          cargo install cross
+          cross build --release --target ${{ env.LINUX_TARGET }} -Z registry-auth
+          mv ./target/${{ env.LINUX_TARGET }}/release/ev-cage ./${{ env.BIN_DIR }}/ev-cage
+          7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ./${{ env.RELEASE_DIR }}/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
+          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
+          CARGO_HOME: ${{ github.workspace }}/.cargo
 
       - name: Upload as artifact
         uses: actions/upload-artifact@v2
@@ -63,12 +87,17 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           target: ${{ env.MACOS_TARGET }}
+          override: true
 
-      - run: cargo build --release --target ${{ env.MACOS_TARGET }}
+      - name: Build CLI MacOs Target
+      - run: |
+          cargo install cross
+          cross build --release --target ${{ env.MACOS_TARGET }} -Z registry-auth
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
+          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
 
       - name: Compress macos binary
         uses: svenstaro/upx-action@v2
@@ -109,18 +138,23 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           target: ${{ env.WINDOWS_TARGET }}
+          override: true
 
       - name: Fetch dependencies
-        run: cargo fetch
+        run: cargo fetch -Z registry-auth
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
+          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
 
       - name: Build CLI for Windows
-        run: cargo build --release --target ${{ env.WINDOWS_TARGET }}
+        run: |
+          cargo install cross
+          cross build --release --target ${{ env.WINDOWS_TARGET }} -Z registry-auth
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
+          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
 
       - name: Setup directories
         shell: bash
@@ -140,111 +174,111 @@ jobs:
           name: windows
           path: ./${{ env.RELEASE_DIR }}
 
-  release-cli-version:
-    needs: [ get-version, compile-ubuntu, compile-macos, compile-windows ]
-    runs-on: ubuntu-latest
-    steps:
+  # release-cli-version:
+  #   needs: [ get-version, compile-ubuntu, compile-macos, compile-windows ]
+  #   runs-on: ubuntu-latest
+  #   steps:
 
-      - name: Create Release
-        id: create-release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ needs.get-version.outputs.version }}
-          release_name: ${{ needs.get-version.outputs.version }}
+  #     - name: Create Release
+  #       id: create-release
+  #       uses: actions/create-release@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         tag_name: ${{ needs.get-version.outputs.version }}
+  #         release_name: ${{ needs.get-version.outputs.version }}
 
-      - name: Download MacOS Artifacts
-        uses: actions/download-artifact@v1
-        with:
-          name: macos
+  #     - name: Download MacOS Artifacts
+  #       uses: actions/download-artifact@v1
+  #       with:
+  #         name: macos
 
-      - name: Download Linux Artifacts
-        uses: actions/download-artifact@v1
-        with:
-          name: linux
+  #     - name: Download Linux Artifacts
+  #       uses: actions/download-artifact@v1
+  #       with:
+  #         name: linux
 
-      - name: Download Windows Artifacts
-        uses: actions/download-artifact@v1
-        with:
-          name: windows
+  #     - name: Download Windows Artifacts
+  #       uses: actions/download-artifact@v1
+  #       with:
+  #         name: windows
 
-      - name: Upload Linux Release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ./linux/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
-          asset_content_type: application/gzip
-          asset_name: ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+  #     - name: Upload Linux Release
+  #       uses: actions/upload-release-asset@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         upload_url: ${{ steps.create-release.outputs.upload_url }}
+  #         asset_path: ./linux/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+  #         asset_content_type: application/gzip
+  #         asset_name: ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
 
-      - name: Upload MacOS Release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ./macos/ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
-          asset_content_type: application/gzip
-          asset_name: ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+  #     - name: Upload MacOS Release
+  #       uses: actions/upload-release-asset@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         upload_url: ${{ steps.create-release.outputs.upload_url }}
+  #         asset_path: ./macos/ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+  #         asset_content_type: application/gzip
+  #         asset_name: ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
 
-      - name: Upload Windows Release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ./windows/ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
-          asset_content_type: application/gzip
-          asset_name: ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+  #     - name: Upload Windows Release
+  #       uses: actions/upload-release-asset@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         upload_url: ${{ steps.create-release.outputs.upload_url }}
+  #         asset_path: ./windows/ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+  #         asset_content_type: application/gzip
+  #         asset_name: ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
 
-  upload-artifacts-to-s3:
-    needs: [ get-version , compile-ubuntu, compile-macos, compile-windows ]
-    runs-on: ubuntu-latest
-    steps:
+  # upload-artifacts-to-s3:
+  #   needs: [ get-version , compile-ubuntu, compile-macos, compile-windows ]
+  #   runs-on: ubuntu-latest
+  #   steps:
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
+  #     - name: Configure AWS credentials
+  #       uses: aws-actions/configure-aws-credentials@v1
+  #       with:
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #         aws-region: us-east-1
 
-      - name: Download MacOS Artifacts
-        uses: actions/download-artifact@v1
-        with:
-          name: macos
+  #     - name: Download MacOS Artifacts
+  #       uses: actions/download-artifact@v1
+  #       with:
+  #         name: macos
 
-      - name: Download Linux Artifacts
-        uses: actions/download-artifact@v1
-        with:
-          name: linux
+  #     - name: Download Linux Artifacts
+  #       uses: actions/download-artifact@v1
+  #       with:
+  #         name: linux
 
-      - name: Download Windows Artifacts
-        uses: actions/download-artifact@v1
-        with:
-          name: windows
+  #     - name: Download Windows Artifacts
+  #       uses: actions/download-artifact@v1
+  #       with:
+  #         name: windows
 
-      - name: Upload Windows CLI to S3
-        run: |
-          aws s3 cp ./windows/ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.WINDOWS_TARGET }}/ev-cage.tar.gz
+  #     - name: Upload Windows CLI to S3
+  #       run: |
+  #         aws s3 cp ./windows/ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.WINDOWS_TARGET }}/ev-cage.tar.gz
 
-      - name: Upload MacOS CLI to S3
-        run: |
-          aws s3 cp ./macos/ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.MACOS_TARGET }}/ev-cage.tar.gz
+  #     - name: Upload MacOS CLI to S3
+  #       run: |
+  #         aws s3 cp ./macos/ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.MACOS_TARGET }}/ev-cage.tar.gz
 
-      - name: Upload Ubuntu CLI to S3
-        run: |
-          aws s3 cp ./linux/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.LINUX_TARGET }}/ev-cage.tar.gz
+  #     - name: Upload Ubuntu CLI to S3
+  #       run: |
+  #         aws s3 cp ./linux/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.LINUX_TARGET }}/ev-cage.tar.gz
 
-      - uses: actions/checkout@v2
-      - name: Update install script in S3
-        run: |
-          sh ./scripts/generate-installer.sh ${{ needs.get-version.outputs.version }}
-          aws s3 cp scripts/install s3://cage-build-assets-${{ env.STAGE }}/cli/${{needs.get-version.outputs.version}}/install
-          aws s3 cp scripts/install s3://cage-build-assets-${{ env.STAGE }}/cli/install
-          aws s3 cp scripts/version s3://cage-build-assets-${{ env.STAGE }}/cli/${{needs.get-version.outputs.version}}/version
-          aws s3 cp scripts/version s3://cage-build-assets-${{ env.STAGE }}/cli/version
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/cli/install"
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/cli/version"
+  #     - uses: actions/checkout@v2
+  #     - name: Update install script in S3
+  #       run: |
+  #         sh ./scripts/generate-installer.sh ${{ needs.get-version.outputs.version }}
+  #         aws s3 cp scripts/install s3://cage-build-assets-${{ env.STAGE }}/cli/${{needs.get-version.outputs.version}}/install
+  #         aws s3 cp scripts/install s3://cage-build-assets-${{ env.STAGE }}/cli/install
+  #         aws s3 cp scripts/version s3://cage-build-assets-${{ env.STAGE }}/cli/${{needs.get-version.outputs.version}}/version
+  #         aws s3 cp scripts/version s3://cage-build-assets-${{ env.STAGE }}/cli/version
+  #         aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/cli/install"
+  #         aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/cli/version"

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -24,8 +24,8 @@ jobs:
     steps:
       - id: get-version
         run: |
-          echo "using version tag 0.1.15"
-          echo ::set-output name=version::0.1.15
+          echo "using version tag ${GITHUB_REF:11}"
+          echo ::set-output name=version::${GITHUB_REF:11}
 
   compile-ubuntu:
     runs-on: ubuntu-latest

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -7,6 +7,7 @@ use crate::enclave::{EIFMeasurements, ENCLAVE_FILENAME};
 use crate::progress::{get_tracker, poll_fn_and_report_status, ProgressLogger, StatusReport};
 use std::io::Write;
 mod error;
+use async_stream::__private::AsyncStream;
 use error::DeployError;
 use reqwest::Body;
 use std::path::Path;
@@ -14,7 +15,6 @@ use tokio::fs::File;
 use tokio::time::timeout;
 use tokio_stream::StreamExt;
 use tokio_util::codec::{BytesCodec, FramedRead};
-use async_stream::__private::AsyncStream;
 
 const ENCLAVE_ZIP_FILENAME: &str = "enclave.zip";
 const DEPLOY_WATCH_TIMEOUT_SECONDS: u64 = 600; //10 minutes
@@ -207,10 +207,7 @@ fn create_zip_archive_for_eif(output_path: &std::path::Path) -> zip::result::Zip
 fn create_zip_upload_stream(
     zip_file: File,
     zip_len_bytes: u64,
-) -> AsyncStream<
-    Result<bytes::BytesMut, std::io::Error>,
-    impl core::future::Future<Output = ()>,
-> {
+) -> AsyncStream<Result<bytes::BytesMut, std::io::Error>, impl core::future::Future<Output = ()>> {
     let mut stream = FramedRead::new(zip_file, BytesCodec::new());
     let progress_bar = get_tracker("Uploading Cage to Evervault", Some(zip_len_bytes));
     async_stream::stream! {

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -14,6 +14,7 @@ use tokio::fs::File;
 use tokio::time::timeout;
 use tokio_stream::StreamExt;
 use tokio_util::codec::{BytesCodec, FramedRead};
+use async_stream::__private::AsyncStream;
 
 const ENCLAVE_ZIP_FILENAME: &str = "enclave.zip";
 const DEPLOY_WATCH_TIMEOUT_SECONDS: u64 = 600; //10 minutes
@@ -31,7 +32,7 @@ pub async fn deploy_eif(
     let zip_path = output_path.path().join(ENCLAVE_ZIP_FILENAME);
     let zip_file = File::open(&zip_path).await?;
     let zip_len_bytes = zip_file.metadata().await?.len();
-    let zip_upload_stream = create_zip_upload_stream(zip_file, zip_len_bytes).await;
+    let zip_upload_stream = create_zip_upload_stream(zip_file, zip_len_bytes);
 
     let eif_size_bytes = get_eif_size_bytes(output_path.path()).await?;
 
@@ -203,10 +204,10 @@ fn create_zip_archive_for_eif(output_path: &std::path::Path) -> zip::result::Zip
     Ok(())
 }
 
-async fn create_zip_upload_stream(
+fn create_zip_upload_stream(
     zip_file: File,
     zip_len_bytes: u64,
-) -> async_stream::AsyncStream<
+) -> AsyncStream<
     Result<bytes::BytesMut, std::io::Error>,
     impl core::future::Future<Output = ()>,
 > {


### PR DESCRIPTION
# Why
Need to start using nightly to pull in rust crypto using the new registry auth.

# How
Updated actions to use cross and nightly so that they can pull in rust crypto. Stopped using cargo-static-builder

There was also an update to async_stream which was breaking so I had to update the CLI code for that
