### PR TITLE
fix: add macro to skip serializing when healthcheck isn't set

### DIFF
--- a/src/api/cage.rs
+++ b/src/api/cage.rs
@@ -252,6 +252,7 @@ pub struct CreateCageDeploymentIntentRequest {
     not_before: String,
     not_after: String,
     metadata: VersionMetadata,
+    #[serde(skip_serializing_if = "Option::is_none")]
     healthcheck: Option<String>,
 }
 


### PR DESCRIPTION
# Why
Old Cage toml's were incompatible with the new healthcheck feature - if the healthcheck wasn't set, the CLI sent `null` which failed validation

# How
Add serde macro to skip serializing the healthcheck value if it's `None`
