### PR TITLE
Add warning on deploy if scaling config differs between local and remote 

### DIFF
--- a/src/cli/deploy.rs
+++ b/src/cli/deploy.rs
@@ -118,9 +118,9 @@ pub async fn run(deploy_args: DeployArgs) -> exitcode::ExitCode {
     let local_replicas = validated_config.scaling.desired_replicas;
 
     // Warn if local scaling config differs from remote
-    let has_scaling_config_drift = cage_scaling_config.as_ref().is_some_and(|config| {
-        config.desired_replicas() != local_replicas
-    });
+    let has_scaling_config_drift = cage_scaling_config
+        .as_ref()
+        .is_some_and(|config| config.desired_replicas() != local_replicas);
     if has_scaling_config_drift {
         let remote_replicas = cage_scaling_config.as_ref().unwrap().desired_replicas();
         log::warn!("Remote scaling config differs from local config. This deployment will apply the local config.\n\nCurrent remote replica count: {remote_replicas}\nLocal replica count: {local_replicas}\n");

--- a/src/cli/scale.rs
+++ b/src/cli/scale.rs
@@ -111,8 +111,9 @@ pub async fn run(args: ScaleArgs) -> i32 {
         let has_scaling_drift = config
             .scaling
             .as_ref()
-            .is_some_and(|scaling| scaling.desired_replicas != scaling_config.desired_replicas());
-        if (args.sync && args.desired_replicas.is_some()) && has_scaling_drift {
+            .map(|scaling| scaling.desired_replicas != scaling_config.desired_replicas())
+            .unwrap_or(true);
+        if (args.sync || args.desired_replicas.is_some()) && has_scaling_drift {
             config.set_scaling_config(ScalingSettings {
                 desired_replicas: scaling_config.desired_replicas(),
             });


### PR DESCRIPTION
# Why
The toml should be treated as the source of truth for a Cages config, but we need to warn users when the config has drifted from the remote state (through scaling events between deployments).

# How
Check the scaling config in the toml vs the remote config, warn the user if they have drifted
