### PR TITLE
Ciant/GitHub OIDC role over access keys

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -18,9 +18,7 @@ on:
     secrets:
       aws-cloudfront-distribution-id:
         required: true
-      aws-access-key-id:
-        required: true
-      aws-secret-access-key:
+      aws-oidc-role-arn:
         required: true
 env:
   RUST_BACKTRACE: 1
@@ -114,8 +112,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.aws-access-key-id }}
-          aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
+          role-to-assume: ${{ secrets.aws-oidc-role-arn }}
           aws-region: us-east-1
       - name: Download MacOS Artifacts
         uses: actions/download-artifact@v4.1.8

--- a/.github/workflows/release-cli-version-staging.yml
+++ b/.github/workflows/release-cli-version-staging.yml
@@ -47,5 +47,5 @@ jobs:
       full-version: "${{ needs.get-version.outputs.full_version }}"
       ev-domain: "evervault.io"
     secrets:
-      aws-oidc-role-arn: ${{ secrets.AWS_EV_CLI_PRODUCTION_OIDC_ROLE_ARN}}
+      aws-oidc-role-arn: ${{ secrets.AWS_EV_CLI_STAGING_OIDC_ROLE_ARN }}
       aws-cloudfront-distribution-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_STAGING }}

--- a/.github/workflows/release-cli-version-staging.yml
+++ b/.github/workflows/release-cli-version-staging.yml
@@ -47,6 +47,5 @@ jobs:
       full-version: "${{ needs.get-version.outputs.full_version }}"
       ev-domain: "evervault.io"
     secrets:
-      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_STAGING }}
-      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_STAGING }}
+      aws-oidc-role-arn: ${{ secrets.AWS_EV_CLI_PRODUCTION_OIDC_ROLE_ARN}}
       aws-cloudfront-distribution-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_STAGING }}

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -42,8 +42,7 @@ jobs:
       full-version: ${{ needs.get-version.outputs.full_version }}
       ev-domain: 'evervault.com'
     secrets:
-      aws-access-key-id: ${{ secrets.PUBLIC_REPO_AWS_ACCESS_KEY_ID }}
-      aws-secret-access-key: ${{ secrets.PUBLIC_REPO_AWS_SECRET_ACCESS_KEY }}
+      aws-oidc-role-arn: ${{ secrets.AWS_EV_CLI_PRODUCTION_OIDC_ROLE_ARN }}
       aws-cloudfront-distribution-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
   release-cli-version:
     needs: [build-and-deploy, get-version]


### PR DESCRIPTION
# Why
Using github oidc instead of access keys
